### PR TITLE
Post-merge polish: UIKit adaptive helper, schema wiring, doc surface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,7 +44,7 @@ playground.xcworkspace
 #
 # Xcode automatically generates this directory with a .xcworkspacedata file and xcuserdata
 # hence it is not needed unless you have added a package configuration file to your project
-# .swiftpm
+.swiftpm/
 
 .build/
 

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<Workspace
-   version = "1.0">
-   <FileRef
-      location = "self:">
-   </FileRef>
-</Workspace>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 ### New (iOS)
 - `MaterialDesignColorCore` — pure-data target (no UI dependency).
 - `MaterialDesignColorSwiftUI` — `Color` extensions + `MaterialTheme` environment.
-- `MaterialDesignColorUIKit` — `UIColor` extensions.
+- `MaterialDesignColorUIKit` — `UIColor` extensions, plus `UIColor.materialBaseline(\.role)` for adaptive light/dark colors via `UIColor(dynamicProvider:)`.
 - `MaterialDesignColor` — umbrella shim re-exporting SwiftUI surface for source-level back-compat with v1.
 
 ### New packages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 - Multi-language packages: iOS (Swift), React Native (TypeScript), Python.
 - Token-driven codegen — `tokens/*.json` is the single source of truth, generated outputs are committed.
 
+### Migrating from v1
+The v1 public surface was the SwiftUI `Color.<token>` extensions (`Color.red50`, `Color.pink400`, ...) shipped from a single `MaterialDesignColor` module. v2 keeps that surface intact through the `MaterialDesignColor` umbrella product, so v1 call sites compile unchanged. New code should prefer `MaterialPalette.<token>` (palette enum) and the M3 surface (`MaterialColorScheme.baselineLight/Dark`, `MaterialTheme`).
+
 ### Breaking changes (iOS)
 - `MaterialColor.init(name:hex:)` is now `internal`. External code should use `MaterialPalette.<name>` or scheme accessors instead of constructing `MaterialColor` directly.
 - `MaterialColorScheme.sourceColor` removed. The source color now lives on `MaterialTheme`:

--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Material color tokens and Material 3 style color schemes for multiple platforms.
 
 ![Badge](https://img.shields.io/badge/swift-white.svg?style=flat-square&logo=Swift)
 ![Badge](https://img.shields.io/badge/SwiftUI-001b87.svg?style=flat-square&logo=Swift&logoColor=black)
+![Badge](https://img.shields.io/badge/React_Native-20232A.svg?style=flat-square&logo=react&logoColor=61DAFB)
+![Badge](https://img.shields.io/badge/Python-3776AB.svg?style=flat-square&logo=python&logoColor=white)
 ![Badge - Version](https://img.shields.io/badge/Version-2.0.0-1177AA?style=flat-square)
 ![Badge - Swift Package Manager](https://img.shields.io/badge/SPM-compatible-orange?style=flat-square)
 ![Badge - Platform](https://img.shields.io/badge/iOS-v13.0-yellow?style=flat-square)

--- a/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
+++ b/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
@@ -13,7 +13,7 @@ public extension UIColor {
   /// For a non-baseline `MaterialColorScheme` pair, build the dynamic color
   /// directly with `UIColor(dynamicProvider:)` and the `MaterialColor`-based
   /// `UIColor(materialColor:)` initializer.
-  @available(iOS 13.0, tvOS 13.0, *)
+  @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   static func materialBaseline(_ role: KeyPath<MaterialColorScheme, MaterialColor>) -> UIColor {
     UIColor { trait in
       let scheme: MaterialColorScheme = trait.userInterfaceStyle == .dark

--- a/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
+++ b/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
@@ -1,0 +1,26 @@
+#if canImport(UIKit)
+import MaterialDesignColorCore
+import UIKit
+
+public extension UIColor {
+  /// Returns a `UIColor` that resolves between the M3 baseline light and dark
+  /// schemes based on the trait collection's `userInterfaceStyle`.
+  ///
+  /// ```swift
+  /// view.backgroundColor = .materialBaseline(\.primary)
+  /// ```
+  ///
+  /// For a non-baseline `MaterialColorScheme` pair, build the dynamic color
+  /// directly with `UIColor(dynamicProvider:)` and the `MaterialColor`-based
+  /// `UIColor(materialColor:)` initializer.
+  @available(iOS 13.0, tvOS 13.0, *)
+  static func materialBaseline(_ role: KeyPath<MaterialColorScheme, MaterialColor>) -> UIColor {
+    UIColor { trait in
+      let scheme: MaterialColorScheme = trait.userInterfaceStyle == .dark
+        ? .baselineDark
+        : .baselineLight
+      return UIColor(materialColor: scheme[keyPath: role])
+    }
+  }
+}
+#endif

--- a/tokens/material-colors.json
+++ b/tokens/material-colors.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "./schema.json",
   "red50": "#FFEBEE",
   "red100": "#FFCDD2",
   "red200": "#EF9A9A",

--- a/tokens/schema.json
+++ b/tokens/schema.json
@@ -2,11 +2,14 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "title": "Material Design Color Tokens",
   "type": "object",
-  "propertyNames": {
-    "pattern": "^[a-z][A-Za-z0-9]*$"
+  "properties": {
+    "$schema": { "type": "string" }
   },
-  "additionalProperties": {
-    "type": "string",
-    "pattern": "^#[0-9A-F]{6}$"
-  }
+  "patternProperties": {
+    "^[a-z][A-Za-z0-9]*$": {
+      "type": "string",
+      "pattern": "^#[0-9A-F]{6}$"
+    }
+  },
+  "additionalProperties": false
 }

--- a/tools/codegen/generate.rb
+++ b/tools/codegen/generate.rb
@@ -505,10 +505,14 @@ def python_theme(roles, baseline)
   PYTHON
 end
 
+def load_tokens(path)
+  JSON.parse(File.read(path)).reject { |key, _| key.start_with?("$") }
+end
+
 check = ARGV.include?("--check")
-material2_tokens = JSON.parse(File.read(MATERIAL2_TOKENS_PATH))
+material2_tokens = load_tokens(MATERIAL2_TOKENS_PATH)
 material3_roles = JSON.parse(File.read(MATERIAL3_ROLES_PATH))
-material3_baseline = JSON.parse(File.read(MATERIAL3_BASELINE_PATH))
+material3_baseline = load_tokens(MATERIAL3_BASELINE_PATH)
 
 validate_material2_tokens(material2_tokens)
 validate_material3_tokens(material3_roles, material3_baseline)


### PR DESCRIPTION
## Summary
- Add `UIColor.materialBaseline(\.role)` so UIKit consumers get adaptive M3 light/dark colors without hand-rolling `UIColor(dynamicProvider:)`.
- Wire `tokens/schema.json` (previously dead) via `\$schema` link in `tokens/material-colors.json` so editors flag malformed tokens before codegen runs; teach the generator to skip `\$`-prefixed keys. Also untrack `.swiftpm/` since Xcode regenerates it.
- Add React Native and Python badges to README and a v1→v2 migration note to CHANGELOG (the v1 `Color.<token>` surface still works through the `MaterialDesignColor` umbrella, which wasn't obvious from the breaking-change list alone).

## Test plan
- [x] \`ruby tools/codegen/generate.rb --check\` — generated outputs in sync
- [x] \`swift package clean && swift test\` — 6/6
- [x] \`PYTHONPATH=packages/python/src python3 -m pytest packages/python/tests\` — 3/3
- [x] \`tsc --noEmit\` on the React Native package
- [ ] Manual: confirm UIKit consumer sees `UIColor.materialBaseline(\.primary)` switch when toggling Dark Mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)