### PR TITLE
Revert: "Address PR review: scope load_tokens to M2, skip scheme copy in helper"

### DIFF
--- a/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
+++ b/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
@@ -16,10 +16,10 @@ public extension UIColor {
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   static func materialBaseline(_ role: KeyPath<MaterialColorScheme, MaterialColor>) -> UIColor {
     UIColor { trait in
-      let materialColor = trait.userInterfaceStyle == .dark
-        ? MaterialColorScheme.baselineDark[keyPath: role]
-        : MaterialColorScheme.baselineLight[keyPath: role]
-      return UIColor(materialColor: materialColor)
+      let scheme: MaterialColorScheme = trait.userInterfaceStyle == .dark
+        ? .baselineDark
+        : .baselineLight
+      return UIColor(materialColor: scheme[keyPath: role])
     }
   }
 }

--- a/tools/codegen/generate.rb
+++ b/tools/codegen/generate.rb
@@ -506,17 +506,13 @@ def python_theme(roles, baseline)
 end
 
 def load_tokens(path)
-  # Strip JSON-Schema metadata keys ($schema, etc) so they aren't iterated
-  # as tokens. Only applied to flat token files; M3 files are read raw because
-  # their structure is fixed (sourceColor / variant / contrastLevel / light / dark)
-  # and the generator only reads the keys it knows about.
   JSON.parse(File.read(path)).reject { |key, _| key.start_with?("$") }
 end
 
 check = ARGV.include?("--check")
 material2_tokens = load_tokens(MATERIAL2_TOKENS_PATH)
 material3_roles = JSON.parse(File.read(MATERIAL3_ROLES_PATH))
-material3_baseline = JSON.parse(File.read(MATERIAL3_BASELINE_PATH))
+material3_baseline = load_tokens(MATERIAL3_BASELINE_PATH)
 
 validate_material2_tokens(material2_tokens)
 validate_material3_tokens(material3_roles, material3_baseline)


### PR DESCRIPTION
1bea82d was pushed straight to \`main\` (bypassing the PR flow) to address bot review comments on #4. Revert it so the same change can come back through a reviewable PR.

After this lands, the original change will be reopened as a normal feature branch + PR for review.

## Test plan
- [x] Working tree clean and tests pass with the revert applied
- [ ] Re-introduction PR opened after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)