### PR TITLE
Address PR #4 review: scope load_tokens, skip scheme copy in UIKit helper

### DIFF
--- a/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
+++ b/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
@@ -16,10 +16,10 @@ public extension UIColor {
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   static func materialBaseline(_ role: KeyPath<MaterialColorScheme, MaterialColor>) -> UIColor {
     UIColor { trait in
-      let scheme: MaterialColorScheme = trait.userInterfaceStyle == .dark
-        ? .baselineDark
-        : .baselineLight
-      return UIColor(materialColor: scheme[keyPath: role])
+      let materialColor = trait.userInterfaceStyle == .dark
+        ? MaterialColorScheme.baselineDark[keyPath: role]
+        : MaterialColorScheme.baselineLight[keyPath: role]
+      return UIColor(materialColor: materialColor)
     }
   }
 }

--- a/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
+++ b/packages/ios/Sources/MaterialDesignColorUIKit/UIColor+MaterialBaseline.swift
@@ -3,16 +3,16 @@ import MaterialDesignColorCore
 import UIKit
 
 public extension UIColor {
-  /// Returns a `UIColor` that resolves between the M3 baseline light and dark
-  /// schemes based on the trait collection's `userInterfaceStyle`.
+  /// 트레이트 컬렉션의 `userInterfaceStyle` 에 따라 M3 베이스라인 light / dark
+  /// 스킴 사이를 자동 전환하는 `UIColor` 를 반환한다.
   ///
   /// ```swift
   /// view.backgroundColor = .materialBaseline(\.primary)
   /// ```
   ///
-  /// For a non-baseline `MaterialColorScheme` pair, build the dynamic color
-  /// directly with `UIColor(dynamicProvider:)` and the `MaterialColor`-based
-  /// `UIColor(materialColor:)` initializer.
+  /// 베이스라인이 아닌 커스텀 `MaterialColorScheme` 쌍을 쓰려면
+  /// `UIColor(dynamicProvider:)` 와 `MaterialColor` 기반의
+  /// `UIColor(materialColor:)` 이니셜라이저를 직접 조합하면 된다.
   @available(iOS 13.0, tvOS 13.0, watchOS 6.0, *)
   static func materialBaseline(_ role: KeyPath<MaterialColorScheme, MaterialColor>) -> UIColor {
     UIColor { trait in

--- a/tools/codegen/generate.rb
+++ b/tools/codegen/generate.rb
@@ -506,13 +506,17 @@ def python_theme(roles, baseline)
 end
 
 def load_tokens(path)
+  # Strip JSON-Schema metadata keys ($schema, etc) so they aren't iterated
+  # as tokens. Only applied to flat token files; M3 files are read raw because
+  # their structure is fixed (sourceColor / variant / contrastLevel / light / dark)
+  # and the generator only reads the keys it knows about.
   JSON.parse(File.read(path)).reject { |key, _| key.start_with?("$") }
 end
 
 check = ARGV.include?("--check")
 material2_tokens = load_tokens(MATERIAL2_TOKENS_PATH)
 material3_roles = JSON.parse(File.read(MATERIAL3_ROLES_PATH))
-material3_baseline = load_tokens(MATERIAL3_BASELINE_PATH)
+material3_baseline = JSON.parse(File.read(MATERIAL3_BASELINE_PATH))
 
 validate_material2_tokens(material2_tokens)
 validate_material3_tokens(material3_roles, material3_baseline)

--- a/tools/codegen/generate.rb
+++ b/tools/codegen/generate.rb
@@ -506,10 +506,10 @@ def python_theme(roles, baseline)
 end
 
 def load_tokens(path)
-  # Strip JSON-Schema metadata keys ($schema, etc) so they aren't iterated
-  # as tokens. Only applied to flat token files; M3 files are read raw because
-  # their structure is fixed (sourceColor / variant / contrastLevel / light / dark)
-  # and the generator only reads the keys it knows about.
+  # JSON-Schema 메타 키($schema 등)를 제거해 토큰으로 순회되지 않도록 한다.
+  # 평면 구조의 토큰 파일에만 적용한다. M3 파일은 구조가 고정되어 있고
+  # (sourceColor / variant / contrastLevel / light / dark) 생성기가 알고 있는
+  # 키만 골라 읽으므로 raw 로 파싱한다.
   JSON.parse(File.read(path)).reject { |key, _| key.start_with?("$") }
 end
 


### PR DESCRIPTION
Re-introduction of the change that was force-pushed straight to main as 1bea82d. Stacked on #5 (the revert) so the diff against \`revert/uikit-perf-and-loader-scope\` shows only the actual change. Once #5 merges into main, retarget this PR's base to \`main\`.

## Summary
Two bot reviews against #4 surfaced real issues that landed without going through review:

- **\`tools/codegen/generate.rb\`** — \`load_tokens\` was being applied to the M3 baseline file too. The baseline has a fixed shape (\`sourceColor\` / \`variant\` / \`contrastLevel\` / \`light\` / \`dark\`) and no \`\$\`-prefixed keys, so the filter was a no-op there and just obscured intent. Read the M3 file raw, scope \`load_tokens\` to the flat M2 palette, and document the policy.
- **\`UIColor.materialBaseline(_:)\`** — the dynamic-color closure bound a local of \`MaterialColorScheme\` (a 48-\`MaterialColor\` struct) on every trait change before extracting the single role we needed. Index the static baseline directly by key path so the closure binds only the resulting \`MaterialColor\`.

## Test plan
- [x] \`ruby tools/codegen/generate.rb --check\` clean
- [x] \`swift test\` 6/6 passes
- [ ] After #5 merges, retarget base to main and confirm green CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)