### PR TITLE
Run JS build + ESM smoke at PR time, share smoke script

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -71,15 +71,7 @@ jobs:
 
       - name: Smoke-test the built artifact
         # Catch ESM/CJS or path-resolution regressions before publishing.
-        run: |
-          node --input-type=module -e "
-            import('./dist/index.js').then(m => {
-              if (m.colors.pink400 !== '#EC407A') throw new Error('pink400 mismatch: ' + m.colors.pink400);
-              if (m.lightColorScheme.primary !== '#65558F') throw new Error('lightColorScheme.primary mismatch');
-              if (m.materialSourceColor !== '#6750A4') throw new Error('materialSourceColor mismatch');
-              console.log('ESM smoke test passed.');
-            });
-          "
+        run: npm run smoke
 
       - name: Publish to npm
         run: npm publish --provenance --tag "${TAG:-latest}"

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -25,8 +25,16 @@ jobs:
       run: ruby tools/codegen/generate.rb --check
     - name: Test Swift package
       run: swift test -v
-    - name: Type-check JS package
-      run: npx --yes --package typescript@5.4.5 tsc -p packages/js/tsconfig.json --noEmit
+    - name: Build and smoke-test JS package
+      # Mirror the publish workflow's check + build + ESM smoke so that
+      # packaging regressions (exports map, type: module, import paths)
+      # surface at PR time instead of only at release time.
+      working-directory: packages/js
+      run: |
+        npm install --ignore-scripts --no-package-lock
+        npm run check
+        npm run build
+        npm run smoke
     - name: Test Python package
       run: |
         python3 -m pip install --upgrade pip pytest

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -43,6 +43,7 @@
   "scripts": {
     "build": "tsc -p tsconfig.json",
     "check": "tsc -p tsconfig.json --noEmit",
+    "smoke": "node scripts/smoke.mjs",
     "prepack": "node -e \"require('node:fs').copyFileSync('../../LICENSE','LICENSE')\"",
     "prepare": "npm run build"
   },

--- a/packages/js/scripts/smoke.mjs
+++ b/packages/js/scripts/smoke.mjs
@@ -1,7 +1,9 @@
-// Smoke-tests the built ESM artifact by importing dist/ and asserting
-// known hex values from each public namespace. Catches packaging regressions
-// (ESM/CJS shape, exports map, path resolution) that a type-check alone misses.
-import { colors, lightColorScheme, materialSourceColor } from "../dist/index.js";
+// Smoke-tests the published entry point by importing through the package
+// name (Node "self-referencing"). This routes through package.json's
+// `exports` map and `type` declaration, so a broken exports map, missing
+// `type: "module"`, or wrong `main` would fail here — none of which a
+// relative `../dist/index.js` import would catch.
+import { colors, lightColorScheme, materialSourceColor } from "@swift-man/material-design-color";
 
 const checks = [
   ["colors.pink400", colors.pink400, "#EC407A"],

--- a/packages/js/scripts/smoke.mjs
+++ b/packages/js/scripts/smoke.mjs
@@ -1,0 +1,18 @@
+// Smoke-tests the built ESM artifact by importing dist/ and asserting
+// known hex values from each public namespace. Catches packaging regressions
+// (ESM/CJS shape, exports map, path resolution) that a type-check alone misses.
+import { colors, lightColorScheme, materialSourceColor } from "../dist/index.js";
+
+const checks = [
+  ["colors.pink400", colors.pink400, "#EC407A"],
+  ["lightColorScheme.primary", lightColorScheme.primary, "#65558F"],
+  ["materialSourceColor", materialSourceColor, "#6750A4"],
+];
+
+for (const [label, actual, expected] of checks) {
+  if (actual !== expected) {
+    throw new Error(`${label} mismatch: expected ${expected}, got ${actual}`);
+  }
+}
+
+console.log("ESM smoke test passed.");


### PR DESCRIPTION
Follow-up to #7. Codex flagged across multiple review rounds that the Swift CI workflow only type-checked the JS package, so packaging regressions (broken \`exports\`, missing \`type: module\`, unresolvable internal import) wouldn't surface until the publish workflow tried to ship them — by which point the release tag already exists.

## Summary
- Replace the single \`tsc --noEmit\` step with the same \`install (--ignore-scripts) → check → build → smoke\` sequence the publish workflow runs.
- Extract the smoke logic from the publish workflow's inline \`node -e\` into \`packages/js/scripts/smoke.mjs\` with named imports and per-check error messages.
- Expose it as \`npm run smoke\` so both workflows reference the same script.
- \`scripts/\` is not listed in \`files\`, so it doesn't ship in the npm tarball — verified with \`npm pack --dry-run\`.

## Test plan
- [x] \`npm install --ignore-scripts --no-package-lock && npm run check && npm run build && npm run smoke\` passes locally
- [x] \`ruby tools/codegen/generate.rb --check\` clean
- [x] \`npm pack --dry-run\` does not include \`scripts/\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)