### PR TITLE
docs. DocC API 문서 링크 섹션 추가

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,9 @@ rainbow
 fruitSalad
 ```
 
-Swift API documentation is published with DocC at [docs.gorani.me/MaterialDesignColor/documentation/materialdesigncolorcore](https://docs.gorani.me/MaterialDesignColor/documentation/materialdesigncolorcore/).
+## API Documentation
+
+Swift DocC API documentation for `MaterialDesignColorCore` is available at [docs.gorani.me/MaterialDesignColor/documentation/materialdesigncolorcore](https://docs.gorani.me/MaterialDesignColor/documentation/materialdesigncolorcore/).
 
 ## Installation
 


### PR DESCRIPTION
## 작업 내용
- README 상단에 API Documentation 섹션을 추가했습니다.
- MaterialDesignColorCore DocC API 문서 링크를 명확히 안내했습니다.

## 검증
- git diff --check

## 리뷰 봇 대응
- 리뷰 봇 코멘트가 달리면 합리적 지적/환각 여부를 확인하고, 반영/보류/오탐 판단을 PR 댓글 또는 대댓글에 명시하겠습니다.